### PR TITLE
fix: use "once" instead of "on" in the "once" method

### DIFF
--- a/src/StrictEventEmitter.ts
+++ b/src/StrictEventEmitter.ts
@@ -14,7 +14,7 @@ export class StrictEventEmitter<
   }
 
   once<Event extends keyof EventMap>(event: Event, listener: EventMap[Event]) {
-    return super.on(event.toString(), listener)
+    return super.once(event.toString(), listener)
   }
 
   off<Event extends keyof EventMap>(event: Event, listener: EventMap[Event]) {


### PR DESCRIPTION
Hello!
Thanks for making this library. I've been using it conveniently.
I found a bug when I was using it, so I fixed it. :)

Fixed a bug that "once" was calling “on”.