### PR TITLE
fix: removes all listeners on "removeAllListeners"

### DIFF
--- a/src/StrictEventEmitter.ts
+++ b/src/StrictEventEmitter.ts
@@ -57,7 +57,11 @@ export class StrictEventEmitter<
   }
 
   removeAllListeners<Event extends keyof EventMap>(event?: Event) {
-    return super.removeAllListeners(event ? event.toString() : undefined)
+    if (event) {
+      return super.removeAllListeners(event.toString())
+    }
+
+    return super.removeAllListeners()
   }
 
   eventNames<Event extends keyof EventMap>(): Event[] {

--- a/test/StrictEventEmitter.test.ts
+++ b/test/StrictEventEmitter.test.ts
@@ -1,8 +1,8 @@
 import { StrictEventEmitter } from '../src/StrictEventEmitter'
 
 interface EventsMap {
-  ping: (n: number) => void
-  pong: (n: number) => void
+  ping: (number: number) => void
+  pong: (number: number) => void
 }
 
 it('restricts on/emit methods to the given events map', () => {
@@ -29,6 +29,39 @@ it('dispatches "once" callback only once', () => {
 
   expect(callback).toBeCalledTimes(1)
   expect(callback).toBeCalledWith(5)
+})
+
+describe('removeListener()', () => {
+  it('removes an existing listener', () => {
+    const firstListener = jest.fn()
+    const secondListener = jest.fn()
+    const emitter = new StrictEventEmitter<EventsMap>()
+
+    emitter.on('ping', firstListener)
+    emitter.on('ping', secondListener)
+    emitter.removeListener('ping', firstListener)
+
+    emitter.emit('ping', 5)
+
+    expect(firstListener).not.toHaveBeenCalled()
+    expect(secondListener).toHaveBeenCalledWith(5)
+  })
+
+  it('does nothing given non-existing event name', () => {
+    const callback = jest.fn()
+    const emitter = new StrictEventEmitter<EventsMap>()
+
+    emitter.on('ping', callback)
+    emitter.removeListener(
+      // @ts-expect-error Runtime invalid value.
+      'non-existing',
+      callback
+    )
+
+    emitter.emit('ping', 5)
+
+    expect(callback).toHaveBeenCalledWith(5)
+  })
 })
 
 describe('removeAllListeners()', () => {

--- a/test/StrictEventEmitter.test.ts
+++ b/test/StrictEventEmitter.test.ts
@@ -5,7 +5,7 @@ interface EventsMap {
   pong: (n: number) => void
 }
 
-test('restricts on/emit methods to the given events map', () => {
+it('restricts on/emit methods to the given events map', () => {
   const callback = jest.fn()
   const emitter = new StrictEventEmitter<EventsMap>()
   emitter.on('ping', callback)
@@ -17,7 +17,7 @@ test('restricts on/emit methods to the given events map', () => {
   emitter.removeAllListeners()
 })
 
-test('dispatches "once" callback only once', () => {
+it('dispatches "once" callback only once', () => {
   const callback = jest.fn()
   const emitter = new StrictEventEmitter<EventsMap>()
 
@@ -29,4 +29,33 @@ test('dispatches "once" callback only once', () => {
 
   expect(callback).toBeCalledTimes(1)
   expect(callback).toBeCalledWith(5)
+})
+
+describe('removeAllListeners()', () => {
+  it('removes all listeners when called without any arguments', () => {
+    const callback = jest.fn()
+    const emitter = new StrictEventEmitter<EventsMap>()
+
+    emitter.on('ping', callback)
+    emitter.removeAllListeners()
+
+    emitter.emit('ping', 5)
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('removes all listeners for a specific event', () => {
+    const pingListener = jest.fn()
+    const pongListener = jest.fn()
+    const emitter = new StrictEventEmitter<EventsMap>()
+
+    emitter.on('ping', pingListener)
+    emitter.on('pong', pongListener)
+    emitter.removeAllListeners('ping')
+
+    emitter.emit('ping', 5)
+    expect(pingListener).not.toHaveBeenCalled()
+
+    emitter.emit('pong', 5)
+    expect(pongListener).toHaveBeenCalledWith(5)
+  })
 })


### PR DESCRIPTION
Looks like `.removeAllListeners()` is not working properly. I've noticed this in failing tests for https://github.com/mswjs/msw/actions/runs/3164217459/jobs/5152356375. 