### PR TITLE
fix(Emitter): allow adding listeners to internal events

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -185,7 +185,7 @@ export class Emitter<Events extends EventMap> {
     listener: Listener<Events[EventName]>
   ): this
   public once<EventName extends keyof Events>(
-    eventName: 'newListener' | EventName,
+    eventName: InternalEventNames | EventName,
     listener: Listener<any>
   ): this {
     return this.addListener(
@@ -194,9 +194,17 @@ export class Emitter<Events extends EventMap> {
     )
   }
 
+  public prependListener(
+    eventName: InternalEventNames,
+    listener: InternalListener<Events>
+  ): this
   public prependListener<EventName extends keyof Events>(
     eventName: EventName,
     listener: Listener<Events[EventName]>
+  ): this
+  public prependListener(
+    eventName: InternalEventNames | keyof Events,
+    listener: Listener<any>
   ): this {
     const listeners = this.#getListeners(eventName)
 
@@ -210,9 +218,17 @@ export class Emitter<Events extends EventMap> {
     return this
   }
 
+  public prependOnceListener(
+    eventName: InternalEventNames,
+    listener: InternalListener<Events>
+  ): this
   public prependOnceListener<EventName extends keyof Events>(
     eventName: EventName,
     listener: Listener<Events[EventName]>
+  ): this
+  public prependOnceListener(
+    eventName: InternalEventNames | keyof Events,
+    listener: Listener<any>
   ): this {
     return this.prependListener(
       eventName,
@@ -282,21 +298,25 @@ export class Emitter<Events extends EventMap> {
     return this
   }
 
+  public listeners(eventName: InternalEventNames): Array<Listener<any>>
+  public listeners<EventName extends keyof Events>(
+    eventName: EventName
+  ): Array<Listener<Events[EventName]>>
   /**
    * Returns a copy of the array of listeners for the event named `eventName`.
    */
-  public listeners<EventName extends keyof Events>(
-    eventName: EventName
-  ): Array<Listener<Events[EventName]>> {
+  public listeners(eventName: InternalEventNames | keyof Events) {
     return Array.from(this.#getListeners(eventName))
   }
 
+  public listenerCount(eventName: InternalEventNames): number
+  public listenerCount<EventName extends keyof Events>(
+    eventName: EventName
+  ): number
   /**
    * Returns the number of listeners listening to the event named `eventName`.
    */
-  public listenerCount<EventName extends keyof Events>(
-    eventName: EventName
-  ): number {
+  public listenerCount(eventName: InternalEventNames | keyof Events): number {
     return this.#getListeners(eventName).length
   }
 

--- a/test/Emitter.test-d.ts
+++ b/test/Emitter.test-d.ts
@@ -39,6 +39,10 @@ emitter.once('removeListener', (event, listener) => {
   event.toUpperCase()
   listener.name.toUpperCase()
 })
+emitter.on('newListener', (event, listener) => {
+  event.toUpperCase()
+  listener.name.toUpperCase()
+})
 emitter.on('removeListener', (event, listener) => {
   event.toUpperCase()
   listener.name.toUpperCase()
@@ -62,6 +66,14 @@ emitter.once(
 
 emitter.addListener('hello', (name) => name.toUpperCase())
 emitter.addListener('goodbye', (name) => name.toUpperCase())
+emitter.addListener('newListener', (event, listener) => {
+  event.toUpperCase()
+  listener.name.toUpperCase()
+})
+emitter.addListener('removeListener', (event, listener) => {
+  event.toUpperCase()
+  listener.name.toUpperCase()
+})
 emitter.addListener(
   // @ts-expect-error Invalid event name.
   'unknown',
@@ -81,6 +93,8 @@ emitter.removeListener(
 
 emitter.off('hello', () => {})
 emitter.off('goodbye', () => {})
+emitter.off('newListener', () => {})
+emitter.off('removeListener', () => {})
 emitter.off(
   // @ts-expect-error Invalid event name.
   'unknown',
@@ -89,6 +103,8 @@ emitter.off(
 
 emitter.removeAllListeners('hello')
 emitter.removeAllListeners('goodbye')
+emitter.removeAllListeners('newListener')
+emitter.removeAllListeners('removeListener')
 emitter.removeAllListeners()
 emitter.removeAllListeners(
   // @ts-expect-error Invalid event name.

--- a/test/Emitter.test-d.ts
+++ b/test/Emitter.test-d.ts
@@ -110,3 +110,16 @@ emitter.removeAllListeners(
   // @ts-expect-error Invalid event name.
   'unknown'
 )
+
+/**
+ * .listenerCount()
+ */
+emitter.listenerCount('hello')
+emitter.listenerCount('goodbye')
+emitter.listenerCount('newListener')
+emitter.listenerCount('removeListener')
+
+emitter.listenerCount(
+  // @ts-expect-error Invalid event name.
+  'unknown'
+)


### PR DESCRIPTION
It's totally possible to add `newListener` and `removeListener` listeners in the same way you add regular listeners, e.g. using `on()` or `addListener()`. 