### PR TITLE
fix: compile to es6 instead of the next version

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es6",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",


### PR DESCRIPTION
The resulting npm package contained files that could not be parsed directly, hence compiling to a target more compatible with other tooling