### PR TITLE
fix: multiple same-event "once" listeners should all be called

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -119,7 +119,7 @@ export class Emitter<Events extends EventMap> {
     eventName: EventName,
     ...data: Events[EventName]
   ): boolean {
-    const listeners = this._getListeners(eventName)
+    const listeners = [...this._getListeners(eventName)]
     listeners.forEach((listener) => {
       listener.apply(this, data)
     })

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -56,7 +56,9 @@ export class Emitter<Events extends EventMap> {
   private _getListeners<EventName extends keyof Events>(
     eventName: EventName
   ): Array<Listener<Array<unknown>>> {
-    return this.events.get(eventName) || []
+    // Always return a copy of the listeners array
+    // so they are fixed at the time of the "_getListeners" call.
+    return Array.prototype.concat.apply([], this.events.get(eventName)) || []
   }
 
   private _removeListener<EventName extends keyof Events>(
@@ -80,6 +82,9 @@ export class Emitter<Events extends EventMap> {
       this.removeListener(eventName, onceListener)
       listener.apply(this, data)
     }
+
+    // Inherit the name of the original listener.
+    Object.defineProperty(onceListener, 'name', { value: listener.name })
 
     return onceListener
   }
@@ -119,7 +124,7 @@ export class Emitter<Events extends EventMap> {
     eventName: EventName,
     ...data: Events[EventName]
   ): boolean {
-    const listeners = [...this._getListeners(eventName)]
+    const listeners = this._getListeners(eventName)
     listeners.forEach((listener) => {
       listener.apply(this, data)
     })

--- a/test/Emitter/once.test.ts
+++ b/test/Emitter/once.test.ts
@@ -36,3 +36,27 @@ it('can have multiple once listeners for different events', () => {
   expect(emitter.listenerCount('hello')).toBe(0)
   expect(emitter.listenerCount('goodbye')).toBe(0)
 })
+
+it('emits multiple "once" event of the same name', () => {
+  const emitter = new Emitter<Events>()
+  const firstHelloListener = jest.fn()
+  const secondHelloListener = jest.fn()
+
+  Object.defineProperty(firstHelloListener, 'name', {
+    value: 'firstHelloListener',
+  })
+  Object.defineProperty(secondHelloListener, 'name', {
+    value: 'secondHelloListener',
+  })
+
+  emitter.once('hello', firstHelloListener)
+  emitter.once('hello', secondHelloListener)
+
+  emitter.emit('hello', 'John')
+
+  expect(firstHelloListener).toHaveBeenCalledTimes(1)
+  expect(firstHelloListener).toHaveBeenCalledWith('John')
+
+  expect(secondHelloListener).toHaveBeenCalledTimes(1)
+  expect(secondHelloListener).toHaveBeenCalledWith('John')
+})


### PR DESCRIPTION
The index changes and does not loop correctly because it directly references the array being manipulated by "_removeListener".
We work around the problem by copying the array once.

p.s. I am not good at English, so I may be saying something strange. This is a translation by DeepL.

---

CI is failing so I'm attaching the local test results :)
```shell
$ pnpm test

> strict-event-emitter@0.5.0 test /Users/come25136/developments/apps/come25136/strict-event-emitter
> jest

 PASS  test/Emitter/removeListener.test.ts
 PASS  test/Emitter/prependListener.test.ts
 PASS  test/Emitter/maxListeners.test.ts
 PASS  test/Emitter/once.test.ts
 PASS  test/Emitter/listenerCount.test.ts
 PASS  test/Emitter/emit.test.ts
 PASS  test/Emitter/removeAllListeners.test.ts
 PASS  test/Emitter/on.test.ts

Test Suites: 8 passed, 8 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        1.674 s, estimated 2 s
Ran all test suites.
```