### PR TITLE
docs: fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ npm install strict-event-emitter
 ```ts
 import { Emitter } from 'strict-event-emitter'
 
-// 1. Define an interface that describes your events.
+// 1. Define a type that describes your events.
 // Set event names as the keys, and their expected payloads as values.
-interface Events {
+type Events = {
   connect: [id: string]
   disconnect: [id: string]
 }


### PR DESCRIPTION
Using an interface to define events [triggers](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgURMGMCmU4F84BmUEIcA5AM4xTADGMAtJgG6YB2jmaG2ZAUHwD0guAEYAdHAAimAsDaY4AQzZx5WKASW1FMABZL4AE0wVaNAEam4ATwgBXHC3YwK4oSIDKmeM45w2JRBrJQo4fUUAa0wbCgAaZTYjcL1MYCcADzBMekxksCUbABsIJSMw0LhmJSL7U3d1bC0dFFYOMIQ+ODhaCDYFegAuOABtYCNhqho2AHMAXS64I2AzPoGYYbGJuCn5eb5cAWE4ACZJAGEoTENFJR3qOl9uDUT80LCIuDAr5mAHCiKNiWsnkeTgACJkG1XOCPMowugwnIoFQ4DN2Ng6MooDN7MEOO5emxUVx0C8ALwBTAAdxQz2wAB4oS4KAA+AAUAEojiIAMySACqFF0qQhpJ4UHBKUUFCCimphVsDjIyXswulcCuuKKShwkOhqDJ2Cl8ioKh07nFGnEZSMABkVlgFFB2WQiesyAl2eNOXByazELhuVbsOJxa73TkYJ7yEoLLQGKITryyNygA) a TypeScript error:
> Type 'Events' does not satisfy the constraint 'EventMap'.
>   Index signature for type 'string' is missing in type 'Events'.

This is due to a peculiar behavior of TypeScript compiler that only allows use of types in such curcumstances (see https://github.com/microsoft/TypeScript/issues/15300).

So I replaced the interface with a type. (A type is actually already used in another example above.)

[Playground link](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgURMGMCmU4F84BmUEIcA5AM4xTADGMAtJgG6YB2jmaG2ZAUHwD0guAEYAdHAAimAsDaY4AQzZx5WKASW1FMABZL4AE0wVaNAEam4ATwgBXHC3YwK4oSIDKmeM45w2JRBrJQo4fUUAa0wbCgAaZTYjcL1MYCcADzBMekxksCUbABsIJSMw0LhmJSL7U3cYG2yUVg4wgF5EPjg4Wgg2BXoALjgAbWAjEaoaNgBzAF1uuCNgM37BmBHxybhp+QW+XAFhOAAmSQBhKExDRSVd6jpfbg1E-NCwiLgwa+ZgBwoRRsy1k8jycAARMhWq4IR5lGF0GE5FAqHBZuxsHRlFBZvZghx3H02GiuOhXp0FAB3FAvbAAHmhLgoAD4ABQASmOIgAzJIAKoUXSpSFknhQCEpRQUIKKKmFWwOMjJexCqVwa54opKHBQmGocnYSXyKgqHTuMUacRlIwAGVWWAUUDZZGJGzICTZEw5cHaLMQuC5luw4jFLrdORgHvISgstAYolOPLIXKAA)